### PR TITLE
Fix pdb basename in structure sequence

### DIFF
--- a/EvoSage/prosst_additive.py
+++ b/EvoSage/prosst_additive.py
@@ -97,7 +97,8 @@ def run_prosst(input_seq, pdb_fpath):
 
   # Process structure
   structure_sequence = processor(pdb_fpath)
-  structure_sequence_offset = [i + 3 for i in structure_sequence["2048"][pdb_fpath.split("/")[-1]]["struct"]]
+  structure_key = os.path.basename(pdb_fpath)
+  structure_sequence_offset = [i + 3 for i in structure_sequence["2048"][structure_key]["struct"]]
 
   # Tokenize input sequence
   tokenized_res = tokenizer([input_seq], return_tensors="pt")


### PR DESCRIPTION
## Summary
- use `os.path.basename` for pdb path key

## Testing
- `python -m py_compile EvoSage/prosst_additive.py`

------
https://chatgpt.com/codex/tasks/task_b_683bfe037744832fbcc1200abd4927be