### PR TITLE
Handle empty allowed mutations fallback

### DIFF
--- a/EvoSage/ga_utils.py
+++ b/EvoSage/ga_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import random
+from .prosst_additive import SINGLE_LETTER_CODES
 
 
 def _dominates(a, b):
@@ -138,9 +139,17 @@ def guided_mutate(seq, cand, p_m=0.08):
     Mutation probability per allowed position.
   """
   seq_list = list(seq)
+  mutated = False
   for pos, aa_choices in cand.items():
     if pos < 0 or pos >= len(seq_list):
       continue
     if aa_choices and random.random() < p_m:
       seq_list[pos] = random.choice(aa_choices)
+      mutated = True
+
+  if not cand or not mutated:
+    pos = random.randrange(len(seq_list))
+    fallback_choices = [aa for aa in SINGLE_LETTER_CODES if aa != seq_list[pos]]
+    seq_list[pos] = random.choice(fallback_choices)
+
   return "".join(seq_list)

--- a/EvoSage/main.py
+++ b/EvoSage/main.py
@@ -64,6 +64,12 @@ def _good_single_mutants(scores: pd.DataFrame, wt_seq: str, thr: float) -> List[
 
 def _rand_combination(wt_seq: str, allowed: Dict[int, List[str]], max_k: int) -> str:
     seq = list(wt_seq)
+    if not allowed:
+        pos = random.randrange(len(seq))
+        aa_choices = [aa for aa in SINGLE_LETTER_CODES if aa != wt_seq[pos]]
+        seq[pos] = random.choice(aa_choices)
+        return "".join(seq)
+
     num_mut = random.randint(1, max_k)
     positions = random.sample(list(allowed.keys()), min(num_mut, len(allowed)))
     for p in positions:
@@ -152,6 +158,11 @@ def main() -> None:
 
     scores = run_prosst(wt_seq, pdb)
     allowed = _allowed_mutations(scores, args.neutral_th)
+    if not allowed:
+        allowed = {
+            i: [aa for aa in SINGLE_LETTER_CODES if aa != wt_seq[i]]
+            for i in range(len(wt_seq))
+        }
     pop: List[str] = [wt_seq]
     pop.extend(_good_single_mutants(scores, wt_seq, args.beneficial_th))
     while len(pop) < args.pop_size:


### PR DESCRIPTION
## Summary
- add fallback path in `guided_mutate` so one random residue always mutates
- let `_rand_combination` pick a random site if allowed set is empty
- fallback in `main` uses all positions when `_allowed_mutations` is empty
- remove standalone tests

## Testing
- `ruff check EvoSage tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683fffe1e8bc832fb42f5d0b436c7b3f