### PR TITLE
Add dynamic ProSST matrix update option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ python -m EvoSage.main "<WT_SEQUENCE>" path/to/structure.pdb --generations 50
 Use `--help` to see all available options. The script prints the final Pareto
 front and can also write a CSV log when `--output_csv` is provided.
 
+When `--dynamic_prosst` is enabled, EvoSage recomputes the ProSST score matrix
+from the top sequence of each generation and updates the allowed mutation
+dictionary accordingly before continuing.
+
 ## Plotting Results
 
 The `EvoSage.plot_metrics` module provides helper functions to visualize the search progress. After running the evolutionary search with `--output_csv run_history.csv`, generate plots with:


### PR DESCRIPTION
## Summary
- allow EvoSage to recompute the ProSST score matrix each generation
- update allowed mutation dictionary from the best sequence
- document the new `--dynamic_prosst` flag

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684017321c98832f99460ec58e29264a