### PR TITLE
Add quiet option for EvoEF2 logging

### DIFF
--- a/EvoSage/evoef2.py
+++ b/EvoSage/evoef2.py
@@ -4,7 +4,7 @@ import shutil
 from . import logger
 
 
-def build_mutant(pdb_fpath, mutant_file_path, output_dir):
+def build_mutant(pdb_fpath, mutant_file_path, output_dir, quiet: bool = True):
   """Builds mutant models using EvoEF2.
 
   Parameters
@@ -15,6 +15,8 @@ def build_mutant(pdb_fpath, mutant_file_path, output_dir):
     Path to file with mutations (format: "CA171A,DB180E;").
   output_dir : str
     Output directory for mutant PDB.
+  quiet : bool, optional
+    If True (default), suppress EvoEF2 command logging and output.
 
   Returns
   -------
@@ -57,14 +59,16 @@ def build_mutant(pdb_fpath, mutant_file_path, output_dir):
     f"--pdb={temp_pdb_name}",
     f"--mutant_file={temp_mut_name}",
   ]
-  logger.debug("Executing EvoEF2 command: %s", ' '.join(cmd))
-  logger.debug("EvoEF2 working directory: %s", evoef2_dir)
+  if not quiet:
+    logger.info("Executing EvoEF2 command: %s", ' '.join(cmd))
+    logger.info("EvoEF2 working directory: %s", evoef2_dir)
 
   try:
     result = subprocess.run(cmd, cwd=evoef2_dir, check=True, capture_output=True, text=True)
-    logger.debug("EvoEF2 stdout:\n%s", result.stdout)
-    if result.stderr:
-      logger.debug("EvoEF2 stderr:\n%s", result.stderr)
+    if not quiet:
+      logger.info("EvoEF2 stdout:\n%s", result.stdout)
+      if result.stderr:
+        logger.info("EvoEF2 stderr:\n%s", result.stderr)
 
     # Get list of PDBs in evoef2_dir after running EvoEF2
     final_pdbs_in_evoef2_dir = {f for f in os.listdir(evoef2_dir) if f.endswith(".pdb")}

--- a/EvoSage/main.py
+++ b/EvoSage/main.py
@@ -234,7 +234,7 @@ def main() -> None:
                         mut_file = os.path.join(tmpdir, "mut.txt")
                         with open(mut_file, "w") as fh:
                             fh.write(mut_str)
-                        mut_pdb = build_mutant(pdb, mut_file, tmpdir)
+                        mut_pdb = build_mutant(pdb, mut_file, tmpdir, quiet=True)
                     else:
                         shutil.copy(pdb, os.path.join(tmpdir, "model.pdb"))
                         mut_pdb = os.path.join(tmpdir, "model.pdb")


### PR DESCRIPTION
## Summary
- allow suppressing EvoEF2 logs via a new `quiet` parameter
- route EvoEF2 stdout/stderr through the logger
- call `build_mutant` with `quiet=True` in the main loop