### PR TITLE
Add FASTA output per generation

### DIFF
--- a/EvoSage/main.py
+++ b/EvoSage/main.py
@@ -283,6 +283,13 @@ def main() -> None:
 
         df.insert(0, "gen", gen)
         df.to_csv(gen_dir / "metrics_with_delta.csv", index=False)
+
+        # Save sequences for this generation to a FASTA file
+        fasta_path = gen_dir / "population.fasta"
+        with open(fasta_path, "w") as fh:
+            for i, seq in enumerate(df["seq"], start=1):
+                fh.write(f">seq{i}\n{seq}\n")
+
         final_df = df
 
         score_list = []


### PR DESCRIPTION
## Summary
- write population sequences to a `population.fasta` file in each generation folder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68404004a6d0832fa45e1a6ca02060f8