### PR TITLE
Add reproducible seeding option

### DIFF
--- a/EvoSage/main.py
+++ b/EvoSage/main.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Dict, List, Tuple, Any
 import datetime
+import numpy as np
 
 import pandas as pd
 
@@ -43,6 +44,12 @@ def parse_args() -> argparse.Namespace:
         "--log-level",
         default="INFO",
         help="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducibility",
     )
     return parser.parse_args()
 
@@ -164,6 +171,9 @@ def compute_deltas(mut_metrics: Dict[str, Any], orig_metrics: Dict[str, Any]) ->
 def main() -> None:
     args = parse_args()
     setup_logging(args.log_level)
+    if args.seed is not None:
+        random.seed(args.seed)
+        np.random.seed(args.seed)
 
     wt_seq = args.wt_seq
     pdb = args.pdb

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ python -m EvoSage.main "<WT_SEQUENCE>" path/to/structure.pdb --generations 50
 Use `--help` to see all available options. The script prints the final Pareto
 front and can also write a CSV log when `--output_csv` is provided.
 
+The `--log-level` flag controls logging verbosity and `--seed` sets the
+Python and NumPy random seed for reproducible runs.
+
 When `--dynamic_prosst` is enabled, EvoSage recomputes the ProSST score matrix
 from the top sequence of each generation and updates the allowed mutation
 dictionary accordingly before continuing.


### PR DESCRIPTION
## Summary
- allow specifying a random seed via `--seed`
- seed Python and NumPy PRNGs in `main`
- document `--seed` and `--log-level` usage