### PR TITLE
Improve GA reset logic

### DIFF
--- a/EvoSage/main.py
+++ b/EvoSage/main.py
@@ -425,6 +425,15 @@ def main() -> None:
                 best_overall_seq,
             )
             stale_count = 0
+            pdb_path = destress_cache[best_overall_seq]["pdb_path"]
+            new_scores = run_prosst(best_overall_seq, pdb_path)
+            allowed = _allowed_mutations(new_scores, args.neutral_th)
+            if not allowed:
+                allowed = {
+                    i: [aa for aa in SINGLE_LETTER_CODES if aa != best_overall_seq[i]]
+                    for i in range(len(best_overall_seq))
+                }
+            scores = new_scores
             pop = [best_overall_seq]
             seen_global.add(best_overall_seq)
             while len(pop) < args.pop_size:

--- a/README.md
+++ b/README.md
@@ -106,3 +106,12 @@ plot_final_scatter("run_history.csv", "plots")
 ```
 
 `plot_history` shows how the average additive and z-score metrics evolve per generation, while `plot_final_scatter` plots a pairwise scatter matrix for the last generation.
+
+## Advanced GA Options
+
+When the search stagnates for `--patience` generations, EvoSage now rebuilds the
+ProSST fitness matrix around the best sequence found so far. The allowed mutation
+dictionary is recalculated from this new matrix and subsequent additive scoring
+uses the updated values. This helps the algorithm escape local optima by
+re-seeding the population with mutations that are neutral or beneficial relative
+to the new best sequence.


### PR DESCRIPTION
## Summary
- call ProSST again when the search plateaus
- refresh allowed mutation dictionary using the updated matrix
- document new behaviour under **Advanced GA Options**