### PR TITLE
Improve fallback mutation selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,5 @@ dictionary is recalculated from this new matrix and subsequent additive scoring
 uses the updated values. This helps the algorithm escape local optima by
 re-seeding the population with mutations that are neutral or beneficial relative
 to the new best sequence.
+
+Fallback mutations are guided by the ProSST matrix even when no allowed sites remain. Positions are ranked by the number and sum of negative scores, and random choices are drawn from the best-ranked (least deleterious) sites.


### PR DESCRIPTION
## Summary
- add `rank_negative_sites` helper to prioritize ProSST positions
- use fallback ranking in `guided_mutate` and `_rand_combination`
- document ranking-based fallback strategy in README