### PR TITLE
Add mutation_prob option

### DIFF
--- a/EvoSage/main.py
+++ b/EvoSage/main.py
@@ -66,6 +66,12 @@ def parse_args() -> argparse.Namespace:
         help="Recompute ProSST score matrix using best sequence each generation",
     )
     parser.add_argument(
+        "--mutation_prob",
+        type=float,
+        default=0.08,
+        help="Mutation probability per allowed position",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         help="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
@@ -387,7 +393,12 @@ def main() -> None:
             parent = tournament(elite)
             if parent is None:
                 break
-            child = guided_mutate(parent, allowed, fallback_rank=fallback_rank)
+            child = guided_mutate(
+                parent,
+                allowed,
+                p_m=args.mutation_prob,
+                fallback_rank=fallback_rank,
+            )
             attempts += 1
             if child == wt_seq or child in seen_global or child in next_seen:
                 continue

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ around the best sequence found so far.
 When `--dynamic_prosst` is enabled, EvoSage recomputes the ProSST score matrix
 from the top sequence of each generation and updates the allowed mutation
 dictionary accordingly before continuing.
+`--mutation_prob` controls the per-site mutation probability used when
+generating new candidates (default `0.08`). Higher values explore more mutations
+each generation.
 
 ## Plotting Results
 


### PR DESCRIPTION
## Summary
- add `--mutation_prob` argument in EvoSage main
- pass argument to `guided_mutate`
- document mutation probability option in README

## Testing
- `ruff check EvoSage/main.py`

------
https://chatgpt.com/codex/tasks/task_b_68431d606dc8832fb4af5e59bbe8503d