### PR TITLE
Track nondominated sequences across generations

### DIFF
--- a/EvoSage/plot_metrics.py
+++ b/EvoSage/plot_metrics.py
@@ -14,7 +14,7 @@ def plot_history(csv_path: str, output_dir: str = ".", metrics: Iterable[str] | 
     Parameters
     ----------
     csv_path : str
-        Path to the ``--output_csv`` file produced by ``EvoSage.main``.
+        Path to the ``history.csv`` file produced by ``EvoSage.main``.
     output_dir : str, optional
         Where to write the plots. The directory is created if needed.
     metrics : Iterable[str] | None, optional
@@ -46,7 +46,7 @@ def plot_final_scatter(csv_path: str, output_dir: str = ".", metrics: Iterable[s
     Parameters
     ----------
     csv_path : str
-        Path to the ``--output_csv`` file produced by ``EvoSage.main``.
+        Path to the ``history.csv`` file produced by ``EvoSage.main``.
     output_dir : str, optional
         Where to write the plot. The directory is created if needed.
     metrics : Iterable[str] | None, optional

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ python -m EvoSage.main "<WT_SEQUENCE>" path/to/structure.pdb --generations 50
 ```
 
 Use `--help` to see all available options. The script prints the final Pareto
-front and can also write a CSV log when `--output_csv` is provided.
+front and always writes a `history.csv` log inside the run directory.
 
 The `--log-level` flag controls logging verbosity and `--seed` sets the
 Python and NumPy random seed for reproducible runs.
@@ -100,12 +100,12 @@ each generation.
 
 ## Plotting Results
 
-The `EvoSage.plot_metrics` module provides helper functions to visualize the search progress. After running the evolutionary search with `--output_csv run_history.csv`, generate plots with:
+The `EvoSage.plot_metrics` module provides helper functions to visualize the search progress. After running the evolutionary search, use the generated `history.csv` to create plots:
 
 ```python
 from EvoSage.plot_metrics import plot_history, plot_final_scatter
-plot_history("run_history.csv", "plots")
-plot_final_scatter("run_history.csv", "plots")
+plot_history("history.csv", "plots")
+plot_final_scatter("history.csv", "plots")
 ```
 
 `plot_history` shows how the average additive and z-score metrics evolve per generation, while `plot_final_scatter` plots a pairwise scatter matrix for the last generation.


### PR DESCRIPTION
## Summary
- remove deprecated `--output_csv` option
- archive non-dominated sequences across generations
- always store history, final front and archive inside the run directory
- update plotting docs and README to reflect new `history.csv` output