### PR TITLE
Fix empty history log and add generation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Any CLI flags override values from the JSON file.
 
 Use `--help` to see all available options. The script prints the final Pareto
 front and always writes a `history.csv` log inside the run directory.
+Each row of `history.csv` records the generation, sequence and additive/z-score
+metrics for every evaluated candidate. A `pareto_archive.csv` is also produced
+containing the best individual found in each adaptive grid cell along with the
+generation when it was first discovered.
 
 The `--log-level` flag controls logging verbosity and `--seed` sets the
 Python and NumPy random seed for reproducible runs.


### PR DESCRIPTION
## Summary
- log metrics for every evaluated sequence to `history.csv`
- include generation column in Pareto archive and name metric headers
- document new log details in the README

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_b_68489f0f8750832f954f8d2d281fa028