### PR TITLE
Use structural metrics for stagnation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ The `--log-level` flag controls logging verbosity and `--seed` sets the
 Python and NumPy random seed for reproducible runs.
 
 `--patience` specifies how many generations the algorithm tolerates without an
-improved additive score. Once the limit is reached, the population is reset
-around the best sequence found so far.
+improved structural score (sum of z-scores). Once the limit is reached, the
+population is reset around the best sequence found so far.
 
 When `--dynamic_prosst` is enabled, EvoSage recomputes the ProSST score matrix
 from the top sequence of each generation and updates the allowed mutation
@@ -146,14 +146,15 @@ plot_history("history.csv", "plots")
 plot_final_scatter("history.csv", "plots")
 ```
 
-`plot_history` shows how the average additive and z-score metrics evolve per generation, while `plot_final_scatter` plots a pairwise scatter matrix for the last generation.
+`plot_history` shows how the average structural z-score metrics evolve per generation (additive scores are still logged), while `plot_final_scatter` plots a pairwise scatter matrix for the last generation.
 
 ## Advanced GA Options
 
-When the search stagnates for `--patience` generations, EvoSage now rebuilds the
+When the search stagnates for `--patience` generations, EvoSage rebuilds the
 ProSST fitness matrix around the best sequence found so far. The allowed mutation
 dictionary is recalculated from this new matrix and subsequent additive scoring
-uses the updated values. This helps the algorithm escape local optima by
+still guides mutations using the updated values. This helps the algorithm escape
+local optima by
 re-seeding the population with mutations that are neutral or beneficial relative
 to the new best sequence.
 


### PR DESCRIPTION
## Summary
- track stagnation using aggregated structural z-scores
- remove additive from ranking and final NSGA-II sort
- document new stagnation behaviour

## Testing
- `python -m py_compile EvoSage/*.py`

------
https://chatgpt.com/codex/tasks/task_b_68510e379418832fa20457308bc32fe2