### PR TITLE
Add baseline Z-score normalization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ population is reset around the best sequence found so far.
 When `--dynamic_prosst` is enabled, EvoSage recomputes the ProSST score matrix
 from the top sequence of each generation and updates the allowed mutation
 dictionary accordingly before continuing.
+`--baseline-zscores` freezes the mean and standard deviation from generation 0
+for all structural Z-score calculations, providing a consistent baseline for
+stagnation checks.
 `--mutation_prob` controls the per-site mutation probability used when
 generating new candidates (default `0.08`). Higher values explore more mutations
 each generation.


### PR DESCRIPTION
## Summary
- add `--baseline-zscores` CLI flag to EvoSage
- persist mean/std from generation 0 when the flag is active
- compute Z-scores using the baseline statistics across generations
- document the new option in the README